### PR TITLE
Make database generator compatible with PHP < 5.3.6

### DIFF
--- a/b8/Database/Generator.php
+++ b/b8/Database/Generator.php
@@ -45,7 +45,7 @@ class Generator
 				continue;
 			}
 
-			$ext = pathinfo($file->getFilename(), PAPATHINFO_EXTENSION);
+			$ext = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
 			if($ext != 'php')
 			{
 				continue;


### PR DESCRIPTION
The function [DirectoryIterator::getExtension](http://www.php.net/manual/en/directoryiterator.getextension.php) was added in PHP 5.3.6.

This solves the installation of [PHPCI](https://github.com/Block8/PHPCI) with PHP 5.3.3.
