### PR TITLE
Added additional path normalization.

### DIFF
--- a/b8/Http/Request.php
+++ b/b8/Http/Request.php
@@ -31,10 +31,13 @@ class Request
 
         if (isset($_SERVER['PATH_INFO'])) {
             $path = $_SERVER['PATH_INFO'];
-        }
-
-        if (isset($_SERVER['REDIRECT_PATH_INFO'])) {
+        } elseif (isset($_SERVER['REDIRECT_PATH_INFO'])) {
             $path = $_SERVER['REDIRECT_PATH_INFO'];
+        } elseif (isset($_SERVER['SCRIPT_NAME'])) {
+            $script = dirname( $_SERVER['SCRIPT_NAME'] );
+            if (strpos($path, $script) === 0 ) {
+                $path = substr($path, strlen($script));
+            }
         }
 
         $path = explode('?', $path);


### PR DESCRIPTION
When there is no PATH_INFO and no REDIRECT_PATH_INFO given, we assume
the root directory of the application is the directory inside which the
executed script is located.

As proposed in Block8/PHPCI#39.
