### PR TITLE
Fixed PHP warning when config.yml is empty.

### DIFF
--- a/b8/Config.php
+++ b/b8/Config.php
@@ -41,7 +41,12 @@ class Config
         // Path to a YAML file.
         $parser = new YamlParser();
         $yaml = file_get_contents($yamlFile);
-        $this->setArray($parser->parse($yaml));
+        $config = (array)$parser->parse($yaml);
+        if (empty($config)) {
+            return;
+        }
+
+        $this->setArray($config);
     }
 
     /**


### PR DESCRIPTION
I created a config.yml inside the requested directory (PHPCI), and I got this warning:

`Warning: Invalid argument supplied for foreach() in /Users/tobias/Sites/PHPCI/vendor/block8/b8framework/b8/Config.php on line 141`

This pull request checks if the config is empty and if it is not it does not do anything.
