### PR TITLE
added port recognition to db host

### DIFF
--- a/b8/Database.php
+++ b/b8/Database.php
@@ -92,6 +92,11 @@ class Database extends \PDO
                 // Pull the next server:
                 $server = array_shift($servers);
 
+	            if (stristr($server, ':')) {
+		            list($host, $port) = explode(':', $server);
+		            $server = $host . ';port=' . $port;
+	            }
+
                 // Try to connect:
                 try {
                     $connection = new self('mysql:host=' . $server . ';dbname=' . self::$details['db'],


### PR DESCRIPTION
When using a different port than the default one, you can add it like host:port, but the PDO constructor expects another format:

new PDO('mysql:host=xxx;port=xxx;dbname=xxx', 'xxx', 'xxx', array( PDO::ATTR_PERSISTENT => false));

So this litte change now makes it possible to write host:port to the config and it will be reformatted correctly.
