### PR TITLE
Avoid duplicating \\ due empty namespace

### DIFF
--- a/b8/Application.php
+++ b/b8/Application.php
@@ -97,10 +97,13 @@ class Application
     public function getController()
     {
         if (empty($this->controller)) {
-            $namespace = $this->toPhpName($this->route['namespace']);
-            $controller = $this->toPhpName($this->route['controller']);
-            $appNs = $this->config->get('b8.app.namespace');
-            $controllerClass = $appNs . '\\' . $namespace . '\\' . $controller . 'Controller';
+            $controllerClass = implode('\\', array_filter(
+                array(
+                    $this->config->get('b8.app.namespace'),
+                    $this->toPhpName($this->route['namespace']),
+                    $this->toPhpName($this->route['controller']) . 'Controller'
+                )
+            ));
             $this->controller = $this->loadController($controllerClass);
         }
 
@@ -117,11 +120,13 @@ class Application
 
     protected function controllerExists($route)
     {
-        $namespace = $this->toPhpName($route['namespace']);
-        $controller = $this->toPhpName($route['controller']);
-
-        $appNs = $this->config->get('b8.app.namespace');
-        $controllerClass = $appNs . '\\' . $namespace . '\\' . $controller . 'Controller';
+        $controllerClass = implode('\\', array_filter(
+            array(
+                $this->config->get('b8.app.namespace'),
+                $this->toPhpName($this->route['namespace']),
+                $this->toPhpName($this->route['controller']) . 'Controller'
+            )
+        ));
 
         return class_exists($controllerClass);
     }


### PR DESCRIPTION
I was getting the following error

```
PHP Fatal error:  Class 'PHPCI\\Controller' not found in /srv/http/phpci/vendor/blo 
ck8/b8framework/b8/Application.php on line 93
```
